### PR TITLE
Bump go-dynect client version to v0.5.1

### DIFF
--- a/vendor/github.com/nesv/go-dynect/dynect/client.go
+++ b/vendor/github.com/nesv/go-dynect/dynect/client.go
@@ -8,17 +8,45 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strings"
+	"time"
 )
 
 const (
 	DynAPIPrefix = "https://api.dynect.net/REST"
 )
 
+var (
+	PollingInterval  = 1 * time.Second
+	ErrPromotedToJob = errors.New("promoted to job")
+	ErrRateLimited   = errors.New("too many requests")
+)
+
+// handleJobRedirect overrides the net/http.DefaultClient's redirection policy
+// function.
+//
+// This function will set the Content-Type, and Auth-Token headers, so that we
+// don't get an error back from the API.
+func handleJobRedirect(req *http.Request, via []*http.Request) error {
+	// Set the Content-Type header.
+	req.Header.Set("Content-Type", "application/json")
+
+	// Now, try and divine the Auth-Token header's value from previous
+	// requests.
+	for _, r := range via {
+		if authHdr := r.Header.Get("Auth-Token"); authHdr != "" {
+			req.Header.Set("Auth-Token", authHdr)
+			return nil
+		}
+	}
+	return fmt.Errorf("failed to set Auth-Token header from previous requests")
+}
+
 // A client for use with DynECT's REST API.
 type Client struct {
 	Token        string
 	CustomerName string
-	httpclient   *http.Client
+	transport    *http.Transport
 	verbose      bool
 }
 
@@ -26,7 +54,8 @@ type Client struct {
 func NewClient(customerName string) *Client {
 	return &Client{
 		CustomerName: customerName,
-		httpclient:   &http.Client{}}
+		transport:    &http.Transport{Proxy: http.ProxyFromEnvironment},
+	}
 }
 
 // Enable, or disable verbose output from the client.
@@ -65,19 +94,40 @@ func (c *Client) Logout() error {
 	return c.Do("DELETE", "Session", nil, nil)
 }
 
+// newRequest creates a new *http.Request, and sets the following headers:
+// <ul>
+// <li>Auth-Token</li>
+// <li>Content-Type</li>
+// </ul>
+func (c *Client) newRequest(method, urlStr string, data []byte) (*http.Request, error) {
+	var r *http.Request
+	var err error
+
+	if data != nil {
+		r, err = http.NewRequest(method, urlStr, bytes.NewReader(data))
+	} else {
+		r, err = http.NewRequest(method, urlStr, nil)
+	}
+
+	r.Header.Set("Auth-Token", c.Token)
+	r.Header.Set("Content-Type", "application/json")
+
+	return r, err
+}
+
 func (c *Client) Do(method, endpoint string, requestData, responseData interface{}) error {
 	// Throw an error if the user tries to make a request if the client is
 	// logged out/unauthenticated, but make an exemption for when the
 	// caller is trying to log in.
 	if !c.LoggedIn() && method != "POST" && endpoint != "Session" {
-		return errors.New("Will not perform request; httpclient is closed")
+		return errors.New("Will not perform request; client is closed")
 	}
 
 	var err error
 
 	// Marshal the request data into a byte slice.
 	if c.verbose {
-		log.Println("Marshaling request data")
+		log.Println("dynect: marshaling request data")
 	}
 	var js []byte
 	if requestData != nil {
@@ -89,60 +139,135 @@ func (c *Client) Do(method, endpoint string, requestData, responseData interface
 		return err
 	}
 
-	// Create a new http.Request object, and set the necessary headers to
-	// authorize the request, and specify the content type.
-	url := fmt.Sprintf("%s/%s", DynAPIPrefix, endpoint)
-	var req *http.Request
-	req, err = http.NewRequest(method, url, bytes.NewReader(js))
+	urlStr := fmt.Sprintf("%s/%s", DynAPIPrefix, endpoint)
+
+	// Create a new http.Request.
+	req, err := c.newRequest(method, urlStr, js)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Auth-Token", c.Token)
-	req.Header.Set("Content-Type", "application/json")
 
 	if c.verbose {
-		log.Printf("Making %s request to %q", method, url)
+		log.Printf("Making %s request to %q", method, urlStr)
 	}
 
 	var resp *http.Response
-	resp, err = c.httpclient.Do(req)
+	resp, err = c.transport.RoundTrip(req)
+
 	if err != nil {
 		if c.verbose {
 			respBody, _ := ioutil.ReadAll(resp.Body)
 			log.Printf("%s", string(respBody))
 		}
 		return err
-	} else if resp.StatusCode != 200 {
-		if c.verbose {
-			// Print out the response body.
-			respBody, _ := ioutil.ReadAll(resp.Body)
-			log.Printf("%s", string(respBody))
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case 200:
+		if resp.ContentLength == 0 {
+			// Zero-length content body?
+			log.Println("dynect: warning: zero-length response body; skipping decoding of response")
+			return nil
 		}
-		return errors.New(fmt.Sprintf("Bad response, got %q", resp.Status))
-	}
 
-	// Unmarshal the response data into the provided struct.
-	if c.verbose {
-		log.Println("Reading in response data")
-	}
-	var respBody []byte
-	respBody, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	if c.verbose {
-		log.Println("Unmarshaling response data")
-	}
-	err = json.Unmarshal(respBody, &responseData)
-	if err != nil {
-		respBody, _ := ioutil.ReadAll(resp.Body)
-		if resp.ContentLength == 0 || resp.ContentLength == -1 {
-			log.Println("Zero-length content body")
-		} else {
-			log.Printf("%s", string(respBody))
+		//dec := json.NewDecoder(resp.Body)
+		text, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("Could not read response body")
 		}
+		if err := json.Unmarshal(text, &responseData); err != nil {
+			return fmt.Errorf("Error unmarshalling response:", err)
+		}
+
+		return nil
+
+	case 307:
+		// Handle the temporary redirect, which should point to a
+		// /REST/Jobs endpoint.
+		loc := resp.Header.Get("Location")
+		log.Println("dynect: request is taking too long to complete: redirecting to", loc)
+
+		// Going in to this blind, the documentation says that it will
+		// return a URI when promoting a long-running request to a
+		// job.
+		//
+		// Since a URL is technically a URI, we should do some checks
+		// on the returned URI to sanitize it, and make sure that it is
+		// in the format we would like it to be.
+		if strings.HasPrefix(loc, "/REST/") {
+			loc = strings.TrimLeft(loc, "/REST/")
+		}
+		if !strings.HasPrefix(loc, DynAPIPrefix) {
+			loc = fmt.Sprintf("%s/%s", DynAPIPrefix, loc)
+		}
+
+		log.Println("Fetching location:", loc)
+
+		// Generate a new request.
+		req, err := c.newRequest("GET", loc, nil)
+		if err != nil {
+			return err
+		}
+
+		var jobData JobData
+
+		// Poll the API endpoint, until we get a response back.
+		for {
+			select {
+			case <-time.After(PollingInterval):
+				resp, err := c.transport.RoundTrip(req)
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+
+				text, err := ioutil.ReadAll(resp.Body)
+				//log.Println(string(text))
+				if err != nil {
+					return fmt.Errorf("Could not read response body:", err)
+				}
+				if err := json.Unmarshal(text, &jobData); err != nil {
+					return fmt.Errorf("failed to decode job response body:", err)
+				}
+
+				// Check to see the status of the job.
+				//
+				// If it is "incomplete", loop around again.
+				//
+				// Should the job's status be "success", then
+				// return the data, business-as-usual.
+				//
+				// TODO(nesv): Figure out what to do in the
+				// event of a "failure" job status.
+
+				switch jobData.Status {
+				case "incomplete":
+					continue
+				case "success":
+					if err := json.Unmarshal(text, &responseData); err != nil {
+						return fmt.Errorf("failed to decode response body:", err)
+					}
+					return nil
+				case "failure":
+					return fmt.Errorf("request failed: %v", jobData.Messages)
+				}
+			}
+		}
+
+		return nil
+
+	case 429:
+		return ErrRateLimited
 	}
 
-	return err
+	// If we got here, this means that the client does not know how to
+	// interpret the response, and it should just error out.
+	reason, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read in response body")
+	}
+	return fmt.Errorf("server responded with %v: %v",
+		resp.Status,
+		string(reason))
 }

--- a/vendor/github.com/nesv/go-dynect/dynect/convenient_client.go
+++ b/vendor/github.com/nesv/go-dynect/dynect/convenient_client.go
@@ -18,7 +18,7 @@ func NewConvenientClient(customerName string) *ConvenientClient {
 	return &ConvenientClient{
 		Client{
 			CustomerName: customerName,
-			httpclient:   &http.Client{},
+			transport:    &http.Transport{Proxy: http.ProxyFromEnvironment},
 		}}
 }
 
@@ -119,11 +119,20 @@ func (c *ConvenientClient) GetRecord(record *Record) error {
 	switch rec.Data.RecordType {
 	case "A", "AAAA":
 		record.Value = rec.Data.RData.Address
+	case "ALIAS":
+		record.Value = rec.Data.RData.Alias
 	case "CNAME":
 		record.Value = rec.Data.RData.CName
+	case "MX":
+		record.Value = fmt.Sprintf("%d %s", rec.Data.RData.Preference, rec.Data.RData.Exchange)
+	case "NS":
+		record.Value = rec.Data.RData.NSDName
+	case "SOA":
+		record.Value = rec.Data.RData.RName
 	case "TXT", "SPF":
 		record.Value = rec.Data.RData.TxtData
 	default:
+		fmt.Println("unknown response", rec)
 		return fmt.Errorf("Invalid Dyn record type: %s", rec.Data.RecordType)
 	}
 
@@ -138,9 +147,24 @@ func buildRData(r *Record) (DataBlock, error) {
 		rdata = DataBlock{
 			Address: r.Value,
 		}
+	case "ALIAS":
+		rdata = DataBlock{
+			Alias: r.Value,
+		}
 	case "CNAME":
 		rdata = DataBlock{
 			CName: r.Value,
+		}
+	case "MX":
+		rdata = DataBlock{}
+		fmt.Sscanf(r.Value, "%d %s", &rdata.Preference, &rdata.Exchange)
+	case "NS":
+		rdata = DataBlock{
+			NSDName: r.Value,
+		}
+	case "SOA":
+		rdata = DataBlock{
+			RName: r.Value,
 		}
 	case "TXT", "SPF":
 		rdata = DataBlock{

--- a/vendor/github.com/nesv/go-dynect/dynect/dsfs.go
+++ b/vendor/github.com/nesv/go-dynect/dynect/dsfs.go
@@ -1,0 +1,117 @@
+package dynect
+
+// DSFSResponse is used for holding the data returned by a call to
+// "https://api.dynect.net/REST/DSF/" with 'detail: Y'.
+type AllDSFDetailedResponse struct {
+	ResponseBlock
+	Data []DSFService `json:"data"`
+}
+
+// DSFResponse is used for holding the data returned by a call to
+// "https://api.dynect.net/REST/DSF/SERVICE_ID".
+type DSFResponse struct {
+	ResponseBlock
+	Data DSFService `json:"data"`
+}
+
+// Type DSFService is used as a nested struct, which holds the data for a
+// DSF Service returned by a call to "https://api.dynect.net/REST/DSF/SERVICE_ID".
+type DSFService struct {
+	ID            string       `json:"service_id"`
+	Label         string       `json:"label"`
+	Active        string       `json:"active"`
+	TTL           string       `json:"ttl"`
+	PendingChange string       `json:"pending_change"`
+	Notifiers     []Notifier   `json:"notifiers"`
+	Nodes         []DSFNode    `json:"nodes"`
+	Rulesets      []DSFRuleset `json:"rulesets"`
+}
+
+type DSFRuleset struct {
+	ID            string            `json:"dsf_ruleset_id`
+	Label         string            `json:"label"`
+	CriteriaType  string            `json:"criteria_type"`
+	Criteria      interface{}       `json:"criteria"`
+	Ordering      string            `json:"ordering"`
+	Eligible      string            `json:"eligible"`
+	PendingChange string            `json:"pending_change"`
+	ResponsePools []DSFResponsePool `json:"response_pools"`
+}
+
+type DSFResponsePool struct {
+	ID            string              `json:"dsf_response_pool_id"`
+	Label         string              `json:"label"`
+	Automation    string              `json:"automation"`
+	CoreSetCount  string              `json:"core_set_count"`
+	Eligible      string              `json:"eligible"`
+	PendingChange string              `json:"pending_change"`
+	RsChains      []DSFRecordSetChain `json:"rs_chains"`
+	Rulesets      []DSFRuleset        `json:"rulesets"`
+	Status        string              `json:"status"`
+	LastMonitored string              `json:"last_monitored"`
+	Notifier      string              `json:"notifier"`
+}
+
+type DSFRecordSetChain struct {
+	ID                string         `json:"dsf_record_set_failover_chain_id"`
+	Status            string         `json:"status"`
+	Core              string         `json:"core"`
+	Label             string         `json:"label"`
+	DSFResponsePoolID string         `json:"dsf_response_pool_id"`
+	DSFServiceID      string         `json:"service_id"`
+	PendingChange     string         `json:"pending_change"`
+	DSFRecordSets     []DSFRecordSet `json:"record_sets"`
+}
+
+type DSFRecordSet struct {
+	Status        string      `json:"status"`
+	Eligible      string      `json:"eligible"`
+	ID            string      `json:"dsf_record_set_id"`
+	MonitorID     string      `json:"dsf_monitor_id"`
+	Label         string      `json:"label"`
+	TroubleCount  string      `json:"trouble_count"`
+	Records       []DSFRecord `json:"records"`
+	FailCount     string      `json:"fail_count"`
+	TorpidityMax  string      `json:"torpidity_max"`
+	TTLDerived    string      `json:"ttl_derived"`
+	LastMonitored string      `json:"last_monitored"`
+	TTL           string      `json:"ttl"`
+	ServiceID     string      `json:"service_id"`
+	ServeCount    string      `json:"serve_count"`
+	Automation    string      `json:"automation"`
+	PendingChange string      `json:"pending_change"`
+}
+
+type DSFRecord struct {
+	Status         string   `json:"status"`
+	Endpoints      []string `json:"endpoints"`
+	RDataClass     string   `json:"rdata_class"`
+	Weight         int      `json:"weight"`
+	Eligible       string   `json:"eligible"`
+	ID             string   `json:"dsf_record_id"`
+	DSFRecordSetID string   `json:"dsf_record_set_id"`
+	//RData           interface{} `json:"rdata"`
+	EndpointUpCount int    `json:"endpoint_up_count"`
+	Label           string `json:"label"`
+	MasterLine      string `json:"master_line"`
+	Torpidity       int    `json:"torpidity"`
+	LastMonitored   int    `json:"last_monitored"`
+	TTL             string `json:"ttl"`
+	DSFServiceID    string `json:"service_id"`
+	PendingChange   string `json:"pending_change"`
+	Automation      string `json:"automation"`
+	ReponseTime     int    `json:"response_time"`
+	Publish         string `json:"publish",omit_empty`
+}
+
+type DSFNode struct {
+	Zone string `json:"zone"`
+	FQDN string `json:"fqdn"`
+}
+
+type Notifier struct {
+	ID         int    `json:"notifier_id"`
+	Label      string `json:"label"`
+	Recipients string `json:"recipients"`
+	Active     string `json:"active"`
+}

--- a/vendor/github.com/nesv/go-dynect/dynect/helpers.go
+++ b/vendor/github.com/nesv/go-dynect/dynect/helpers.go
@@ -1,0 +1,30 @@
+package dynect
+
+import "fmt"
+
+func GetAllDSFServicesDetailed(c *Client) (error, []DSFService) {
+	var dsfsResponse AllDSFDetailedResponse
+	requestData := struct {
+		Detail string `json:"detail"`
+	}{Detail: "Y"}
+
+	if err := c.Do("GET", "DSF", requestData, &dsfsResponse); err != nil {
+		return err, nil
+	}
+
+	return nil, dsfsResponse.Data
+}
+
+func GetDSFServiceDetailed(c *Client, id string) (error, DSFService) {
+	var dsfsResponse DSFResponse
+	requestData := struct {
+		Detail string `json:"detail"`
+	}{Detail: "Y"}
+
+	loc := fmt.Sprintf("DSF/%s", id)
+
+	if err := c.Do("GET", loc, requestData, &dsfsResponse); err != nil {
+		return err, DSFService{}
+	}
+	return nil, dsfsResponse.Data
+}

--- a/vendor/github.com/nesv/go-dynect/dynect/job.go
+++ b/vendor/github.com/nesv/go-dynect/dynect/job.go
@@ -1,0 +1,8 @@
+package dynect
+
+type JobData struct {
+	Status   string         `json:"status"`
+	Data     interface{}    `json:"data"`
+	ID       int            `json:"job_id"`
+	Messages []MessageBlock `json:"msgs"`
+}

--- a/vendor/github.com/nesv/go-dynect/dynect/json.go
+++ b/vendor/github.com/nesv/go-dynect/dynect/json.go
@@ -15,7 +15,7 @@ type LoginBlock struct {
 //
 // All response-type structs should include this as an anonymous/embedded field.
 type ResponseBlock struct {
-	Status   string         `json:"string"`
+	Status   string         `json:"status"`
 	JobId    int            `json:"job_id,omitempty"`
 	Messages []MessageBlock `json:"msgs,omitempty"`
 }

--- a/vendor/github.com/nesv/go-dynect/dynect/records.go
+++ b/vendor/github.com/nesv/go-dynect/dynect/records.go
@@ -40,6 +40,9 @@ type DataBlock struct {
 	// A, AAAA
 	Address string `json:"address,omitempty" bson:"address,omitempty"`
 
+	// ALIAS
+	Alias string `json:"alias,omitempty" bson:"alias,omitempty"`
+
 	// CERT, DNSKEY, DS, IPSECKEY, KEY, SSHFP
 	Algorithm string `json:"algorithm,omitempty" bson:"algorithm,omitempty"`
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -518,11 +518,13 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "/iig5lYSPCL3C8J7e4nTAevYNDE=",
+			"checksumSHA1": "zRjEBBbLNC6YHE4ozqcr4OsvfVg=",
 			"comment": "v0.2.0-8-g841842b",
 			"path": "github.com/nesv/go-dynect/dynect",
-			"revision": "2dc6a86cf75ce4b33516d2a13c9c0c378310cf3b",
-			"revisionTime": "2016-04-25T23:31:34Z"
+			"revision": "8ccd652e67c545e82bf455cf84ca0cd783b69767",
+			"revisionTime": "2017-06-05T13:56:06Z",
+			"version": "v0.5.1",
+			"versionExact": "v0.5.1"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",


### PR DESCRIPTION
The `go-dynect` client that this provider uses has had multiple improvements over the last year. This simply bumps the pinned vendor version to `v0.5.1`. I have ran the tests and all succeeded.

This fixes at least these issues, but potentially more:
- #4 Cannot create MX records
- #2 Cannot create NS records