### PR TITLE
r/record: Avoid diff for default TTL

### DIFF
--- a/dyn/resource_dyn_record.go
+++ b/dyn/resource_dyn_record.go
@@ -50,7 +50,7 @@ func resourceDynRecord() *schema.Resource {
 			"ttl": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "0", // 0 means use zone default
+				Computed: true,
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #11 

## Test results

```
TF_ACC=1 go test ./dyn -v -run=TestAccDynRecord_ -timeout 120m
=== RUN   TestAccDynRecord_Basic
--- PASS: TestAccDynRecord_Basic (13.78s)
=== RUN   TestAccDynRecord_noTTL
--- PASS: TestAccDynRecord_noTTL (14.75s)
=== RUN   TestAccDynRecord_Updated
--- FAIL: TestAccDynRecord_Updated (15.97s)
	testing.go:434: Step 1 error: Error applying: 1 error(s) occurred:

		* dyn_record.foobar: 1 error(s) occurred:

		* dyn_record.foobar: Failed to update Dyn record: server responded with 404 Not Found: {"status": "failure", "data": {}, "job_id": 4053968312, "msgs": [{"INFO": "id: You did not reference a specific record", "SOURCE": "BLL", "ERR_CD": "NOT_FOUND", "LVL": "ERROR"}, {"INFO": "update: No record updated", "SOURCE": "BLL", "ERR_CD": null, "LVL": "INFO"}]}
=== RUN   TestAccDynRecord_Multiple
--- PASS: TestAccDynRecord_Multiple (18.74s)
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-dyn/dyn	63.260s
```

`TestAccDynRecord_Updated` was failing for quite a while and resolving the failure is worth a separate PR unrelated to this one.