### PR TITLE
r/record: Ignore trailing dot in FQDN

### DIFF
--- a/dyn/resource_dyn_record.go
+++ b/dyn/resource_dyn_record.go
@@ -3,6 +3,7 @@ package dyn
 import (
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -45,6 +46,19 @@ func resourceDynRecord() *schema.Resource {
 			"value": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				DiffSuppressFunc: func(k, oldV, newV string, d *schema.ResourceData) bool {
+					if d.Get("type").(string) == "CNAME" {
+						// We expect FQDN here, which may or may not have a trailing dot
+						if !strings.HasSuffix(oldV, ".") {
+							oldV += "."
+						}
+						if !strings.HasSuffix(newV, ".") {
+							newV += "."
+						}
+					}
+
+					return oldV == newV
+				},
 			},
 
 			"ttl": &schema.Schema{

--- a/dyn/resource_dyn_record_test.go
+++ b/dyn/resource_dyn_record_test.go
@@ -139,6 +139,30 @@ func TestAccDynRecord_Multiple(t *testing.T) {
 	})
 }
 
+func TestAccDynRecord_CNAME_trailingDot(t *testing.T) {
+	var record dynect.Record
+	zone := os.Getenv("DYN_ZONE")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDynRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckDynRecordConfig_CNAME_trailingDot, zone),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDynRecordExists("dyn_record.foobar", &record),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "name", "www"),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "type", "CNAME"),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "ttl", "3600"),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "zone", zone),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "value", "something.terraform.io."),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDynRecordDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*dynect.ConvenientClient)
 
@@ -270,4 +294,13 @@ resource "dyn_record" "foobar" {
 	name = "terraform"
 	value = "192.168.0.10"
 	type = "A"
+}`
+
+const testAccCheckDynRecordConfig_CNAME_trailingDot = `
+resource "dyn_record" "foobar" {
+  zone  = "%s"
+  name  = "www"
+  value = "something.terraform.io"
+  type  = "CNAME"
+  ttl   = 3600
 }`


### PR DESCRIPTION
Fixes #1 
Fixes #8 

## Test results

```
TF_ACC=1 go test ./dyn -v -run=TestAccDynRecord_ -timeout 120m
=== RUN   TestAccDynRecord_Basic
--- PASS: TestAccDynRecord_Basic (11.09s)
=== RUN   TestAccDynRecord_Updated
--- FAIL: TestAccDynRecord_Updated (22.15s)
	testing.go:434: Step 1 error: Error applying: 1 error(s) occurred:

		* dyn_record.foobar: 1 error(s) occurred:

		* dyn_record.foobar: Failed to update Dyn record: server responded with 404 Not Found: {"status": "failure", "data": {}, "job_id": 4054008527, "msgs": [{"INFO": "id: You did not reference a specific record", "SOURCE": "BLL", "ERR_CD": "NOT_FOUND", "LVL": "ERROR"}, {"INFO": "update: No record updated", "SOURCE": "BLL", "ERR_CD": null, "LVL": "INFO"}]}
=== RUN   TestAccDynRecord_Multiple
--- PASS: TestAccDynRecord_Multiple (28.54s)
=== RUN   TestAccDynRecord_CNAME_trailingDot
--- PASS: TestAccDynRecord_CNAME_trailingDot (12.60s)
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-dyn/dyn	74.402s
```

`TestAccDynRecord_Updated` was failing for quite a while and resolving the failure is worth a separate PR unrelated to this one.