### PR TITLE
r/dyn_record: Support records for top level domain

### DIFF
--- a/dyn/resource_dyn_record.go
+++ b/dyn/resource_dyn_record.go
@@ -30,6 +30,15 @@ func resourceDynRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(k, oldV, newV string, d *schema.ResourceData) bool {
+					// Records for top level domain
+					zone := d.Get("zone").(string)
+					if oldV == zone && newV == "" {
+						return true
+					}
+
+					return oldV == newV
+				},
 			},
 
 			"fqdn": &schema.Schema{

--- a/dyn/resource_dyn_record.go
+++ b/dyn/resource_dyn_record.go
@@ -28,7 +28,7 @@ func resourceDynRecord() *schema.Resource {
 
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 				DiffSuppressFunc: func(k, oldV, newV string, d *schema.ResourceData) bool {
 					// Records for top level domain

--- a/dyn/resource_dyn_record_test.go
+++ b/dyn/resource_dyn_record_test.go
@@ -163,6 +163,30 @@ func TestAccDynRecord_CNAME_trailingDot(t *testing.T) {
 	})
 }
 
+func TestAccDynRecord_CNAME_topLevelDomain(t *testing.T) {
+	var record dynect.Record
+	zone := os.Getenv("DYN_ZONE")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDynRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckDynRecordConfig_topLevelDomain, zone),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDynRecordExists("dyn_record.foobar", &record),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "name", "hashicorptest.com"),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "type", "A"),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "ttl", "90"),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "zone", zone),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "value", "127.0.0.1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDynRecordDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*dynect.ConvenientClient)
 
@@ -303,4 +327,13 @@ resource "dyn_record" "foobar" {
   value = "something.terraform.io"
   type  = "CNAME"
   ttl   = 3600
+}`
+
+const testAccCheckDynRecordConfig_topLevelDomain = `
+resource "dyn_record" "foobar" {
+  zone = "%s"
+  name = ""
+  ttl  = 90
+  type  = "A"
+  value = "127.0.0.1"
 }`

--- a/vendor/github.com/nesv/go-dynect/dynect/client.go
+++ b/vendor/github.com/nesv/go-dynect/dynect/client.go
@@ -156,7 +156,10 @@ func (c *Client) Do(method, endpoint string, requestData, responseData interface
 
 	if err != nil {
 		if c.verbose {
-			respBody, _ := ioutil.ReadAll(resp.Body)
+			respBody, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
 			log.Printf("%s", string(respBody))
 		}
 		return err

--- a/vendor/github.com/nesv/go-dynect/dynect/convenient_client.go
+++ b/vendor/github.com/nesv/go-dynect/dynect/convenient_client.go
@@ -56,7 +56,9 @@ func (c *ConvenientClient) GetRecordID(record *Record) error {
 
 // CreateRecord Method to create a DNS record
 func (c *ConvenientClient) CreateRecord(record *Record) error {
-	if record.FQDN == "" {
+	if record.FQDN == "" && record.Name == "" {
+		record.FQDN = record.Zone
+	} else if record.FQDN == "" {
 		record.FQDN = fmt.Sprintf("%s.%s", record.Name, record.Zone)
 	}
 	rdata, err := buildRData(record)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -544,13 +544,13 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "zRjEBBbLNC6YHE4ozqcr4OsvfVg=",
+			"checksumSHA1": "Fbi/Zx31zEBsAHVUSZBhtETqirQ=",
 			"comment": "v0.2.0-8-g841842b",
 			"path": "github.com/nesv/go-dynect/dynect",
-			"revision": "8ccd652e67c545e82bf455cf84ca0cd783b69767",
-			"revisionTime": "2017-06-05T13:56:06Z",
-			"version": "v0.5.1",
-			"versionExact": "v0.5.1"
+			"revision": "63595f308b6ad3657ebe196b116c740fc2444237",
+			"revisionTime": "2017-08-23T14:40:16Z",
+			"version": "v0.5.3",
+			"versionExact": "v0.5.3"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",


### PR DESCRIPTION
Fixes #6

### Test results

```
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDynRecord_Basic
--- PASS: TestAccDynRecord_Basic (12.65s)
=== RUN   TestAccDynRecord_noTTL
--- PASS: TestAccDynRecord_noTTL (12.24s)
=== RUN   TestAccDynRecord_Updated
--- FAIL: TestAccDynRecord_Updated (19.15s)
	testing.go:434: Step 1 error: Error applying: 1 error(s) occurred:

		* dyn_record.foobar: 1 error(s) occurred:

		* dyn_record.foobar: Failed to update Dyn record: server responded with 404 Not Found: {"status": "failure", "data": {}, "job_id": 4109885045, "msgs": [{"INFO": "id: You did not reference a specific record", "SOURCE": "BLL", "ERR_CD": "NOT_FOUND", "LVL": "ERROR"}, {"INFO": "update: No record updated", "SOURCE": "BLL", "ERR_CD": null, "LVL": "INFO"}]}
=== RUN   TestAccDynRecord_Multiple
--- PASS: TestAccDynRecord_Multiple (18.03s)
=== RUN   TestAccDynRecord_CNAME_trailingDot
--- PASS: TestAccDynRecord_CNAME_trailingDot (11.07s)
=== RUN   TestAccDynRecord_CNAME_topLevelDomain
--- PASS: TestAccDynRecord_CNAME_topLevelDomain (11.64s)
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-dyn/dyn	84.814s
make: *** [testacc] Error 1
```

The update test was broken before.