### PR TITLE
r/dyn_record: Add support for NS & MX records

### DIFF
--- a/dyn/resource_dyn_record.go
+++ b/dyn/resource_dyn_record.go
@@ -56,7 +56,8 @@ func resourceDynRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				DiffSuppressFunc: func(k, oldV, newV string, d *schema.ResourceData) bool {
-					if d.Get("type").(string) == "CNAME" {
+					recordType := d.Get("type").(string)
+					if recordType == "CNAME" || recordType == "NS" {
 						// We expect FQDN here, which may or may not have a trailing dot
 						if !strings.HasSuffix(oldV, ".") {
 							oldV += "."

--- a/dyn/resource_dyn_record.go
+++ b/dyn/resource_dyn_record.go
@@ -57,7 +57,7 @@ func resourceDynRecord() *schema.Resource {
 				Required: true,
 				DiffSuppressFunc: func(k, oldV, newV string, d *schema.ResourceData) bool {
 					recordType := d.Get("type").(string)
-					if recordType == "CNAME" || recordType == "NS" {
+					if recordType == "CNAME" || recordType == "NS" || recordType == "MX" {
 						// We expect FQDN here, which may or may not have a trailing dot
 						if !strings.HasSuffix(oldV, ".") {
 							oldV += "."

--- a/dyn/resource_dyn_record_test.go
+++ b/dyn/resource_dyn_record_test.go
@@ -187,6 +187,30 @@ func TestAccDynRecord_CNAME_topLevelDomain(t *testing.T) {
 	})
 }
 
+func TestAccDynRecord_NS_record(t *testing.T) {
+	var record dynect.Record
+	zone := os.Getenv("DYN_ZONE")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDynRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckDynRecordConfig_NS_record, zone),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDynRecordExists("dyn_record.foobar", &record),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "name", "dev"),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "type", "NS"),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "ttl", "3600"),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "zone", zone),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "value", "ns.terraform.io."),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDynRecordDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*dynect.ConvenientClient)
 
@@ -336,4 +360,13 @@ resource "dyn_record" "foobar" {
   ttl  = 90
   type  = "A"
   value = "127.0.0.1"
+}`
+
+const testAccCheckDynRecordConfig_NS_record = `
+resource "dyn_record" "foobar" {
+    zone  = "%s"
+    name  = "dev"
+    type  = "NS"
+    ttl   = 3600
+    value = "ns.terraform.io"
 }`

--- a/dyn/resource_dyn_record_test.go
+++ b/dyn/resource_dyn_record_test.go
@@ -211,6 +211,30 @@ func TestAccDynRecord_NS_record(t *testing.T) {
 	})
 }
 
+func TestAccDynRecord_MX_record(t *testing.T) {
+	var record dynect.Record
+	zone := os.Getenv("DYN_ZONE")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDynRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckDynRecordConfig_MX_record, zone),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDynRecordExists("dyn_record.foobar", &record),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "name", "mail-test"),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "type", "MX"),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "ttl", "30"),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "zone", zone),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "value", "10 mx.terraform.io."),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDynRecordDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*dynect.ConvenientClient)
 
@@ -369,4 +393,13 @@ resource "dyn_record" "foobar" {
     type  = "NS"
     ttl   = 3600
     value = "ns.terraform.io"
+}`
+
+const testAccCheckDynRecordConfig_MX_record = `
+resource "dyn_record" "foobar" {
+  zone  = "%s"
+  name  = "mail-test"
+  value = "10 mx.terraform.io"
+  type  = "MX"
+  ttl   = 30
 }`


### PR DESCRIPTION
Fixes #2
Fixes #4 

## Test results

```
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDynRecord_Basic
--- PASS: TestAccDynRecord_Basic (11.86s)
=== RUN   TestAccDynRecord_noTTL
--- PASS: TestAccDynRecord_noTTL (12.29s)
=== RUN   TestAccDynRecord_Updated
--- FAIL: TestAccDynRecord_Updated (16.59s)
	testing.go:434: Step 1 error: Error applying: 1 error(s) occurred:

		* dyn_record.foobar: 1 error(s) occurred:

		* dyn_record.foobar: Failed to update Dyn record: server responded with 404 Not Found: {"status": "failure", "data": {}, "job_id": 4109988886, "msgs": [{"INFO": "id: You did not reference a specific record", "SOURCE": "BLL", "ERR_CD": "NOT_FOUND", "LVL": "ERROR"}, {"INFO": "update: No record updated", "SOURCE": "BLL", "ERR_CD": null, "LVL": "INFO"}]}
=== RUN   TestAccDynRecord_Multiple
--- PASS: TestAccDynRecord_Multiple (18.07s)
=== RUN   TestAccDynRecord_CNAME_trailingDot
--- PASS: TestAccDynRecord_CNAME_trailingDot (11.42s)
=== RUN   TestAccDynRecord_NS_record
--- PASS: TestAccDynRecord_NS_record (11.67s)
=== RUN   TestAccDynRecord_MX_record
--- PASS: TestAccDynRecord_MX_record (11.06s)
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-dyn/dyn	92.984s
```