### PR TITLE
r/dyn_record: Remove empty 'name' field

### DIFF
--- a/dyn/resource_dyn_record_test.go
+++ b/dyn/resource_dyn_record_test.go
@@ -380,7 +380,6 @@ resource "dyn_record" "foobar" {
 const testAccCheckDynRecordConfig_topLevelDomain = `
 resource "dyn_record" "foobar" {
   zone = "%s"
-  name = ""
   ttl  = 90
   type  = "A"
   value = "127.0.0.1"


### PR DESCRIPTION
This field is now optional and the test should verify it actually is and everything works ok.

Per conversation in https://github.com/terraform-providers/terraform-provider-dyn/pull/14#discussion_r142345313

## Test results

```
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDynRecord_Basic
--- PASS: TestAccDynRecord_Basic (12.10s)
=== RUN   TestAccDynRecord_noTTL
--- PASS: TestAccDynRecord_noTTL (11.62s)
=== RUN   TestAccDynRecord_Updated
--- FAIL: TestAccDynRecord_Updated (13.69s)
	testing.go:434: Step 1 error: Error applying: 1 error(s) occurred:

		* dyn_record.foobar: 1 error(s) occurred:

		* dyn_record.foobar: Failed to update Dyn record: server responded with 404 Not Found: {"status": "failure", "data": {}, "job_id": 4110041253, "msgs": [{"INFO": "id: You did not reference a specific record", "SOURCE": "BLL", "ERR_CD": "NOT_FOUND", "LVL": "ERROR"}, {"INFO": "update: No record updated", "SOURCE": "BLL", "ERR_CD": null, "LVL": "INFO"}]}
=== RUN   TestAccDynRecord_Multiple
--- PASS: TestAccDynRecord_Multiple (16.32s)
=== RUN   TestAccDynRecord_CNAME_trailingDot
--- PASS: TestAccDynRecord_CNAME_trailingDot (10.91s)
=== RUN   TestAccDynRecord_CNAME_topLevelDomain
--- PASS: TestAccDynRecord_CNAME_topLevelDomain (9.98s)
=== RUN   TestAccDynRecord_NS_record
--- PASS: TestAccDynRecord_NS_record (11.47s)
=== RUN   TestAccDynRecord_MX_record
--- PASS: TestAccDynRecord_MX_record (10.73s)
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-dyn/dyn	96.826s
make: *** [testacc] Error 1
```