### PR TITLE
Add import logic for dyn_record

### DIFF
--- a/dyn/import_dyn_record.go
+++ b/dyn/import_dyn_record.go
@@ -16,7 +16,7 @@ func resourceDynRecordImportState(d *schema.ResourceData, meta interface{}) ([]*
 	values := strings.Split(d.Id(), "/")
 
 	if len(values) != 3 && len(values) != 4 {
-		return nil, fmt.Errorf("invalid id for dyn import provided: %s", d.Id())
+		return nil, fmt.Errorf("invalid id provided, expected format: {type}/{zone}/{fqdn}[/{id}]")
 	}
 
 	recordType := values[0]

--- a/dyn/import_dyn_record.go
+++ b/dyn/import_dyn_record.go
@@ -1,0 +1,66 @@
+package dyn
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/nesv/go-dynect/dynect"
+)
+
+func resourceDynRecordImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	results := make([]*schema.ResourceData, 1, 1)
+
+	client := meta.(*dynect.ConvenientClient)
+
+	values := strings.Split(d.Id(), "/")
+
+	if len(values) != 3 && len(values) != 4 {
+		return nil, fmt.Errorf("invalid id for dyn import provided: %s", d.Id())
+	}
+
+	recordType := values[0]
+	recordZone := values[1]
+	recordFQDN := values[2]
+
+	var recordID string
+	if len(values) == 4 {
+		recordID = values[3]
+	} else {
+		recordID = ""
+	}
+
+	record := &dynect.Record{
+		ID:    recordID,
+		Name:  "",
+		Zone:  recordZone,
+		Value: "",
+		Type:  recordType,
+		FQDN:  recordFQDN,
+		TTL:   "",
+	}
+
+	// If we already have the record ID, use it for the lookup
+	if record.ID == "" {
+		err := client.GetRecordID(record)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err := client.GetRecord(record)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	d.SetId(record.ID)
+	d.Set("name", record.Name)
+	d.Set("zone", record.Zone)
+	d.Set("value", record.Value)
+	d.Set("type", record.Type)
+	d.Set("fqdn", record.FQDN)
+	d.Set("ttl", record.TTL)
+	results[0] = d
+
+	return results, nil
+}

--- a/dyn/import_dyn_record_test.go
+++ b/dyn/import_dyn_record_test.go
@@ -1,0 +1,110 @@
+package dyn
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccImportDynRecord_A(t *testing.T) {
+	zone := os.Getenv("DYN_ZONE")
+
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state: %#v", s)
+		}
+
+		expectedName := "terraform"
+		expectedValue := "192.168.0.10"
+		expectedType := "A"
+		expectedTTL := "3600"
+		return compareState(s[0], expectedName, expectedValue, expectedType, expectedTTL)
+	}
+
+	resourceName := "dyn_record.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDynRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckDynRecordConfig_basic, zone),
+			},
+			resource.TestStep{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateIdPrefix: fmt.Sprintf("A/%s/terraform.%s/", zone, zone),
+				ImportStateCheck:    checkFn,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func TestAccImportDynRecord_MX(t *testing.T) {
+	zone := os.Getenv("DYN_ZONE")
+
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state: %#v", s)
+		}
+
+		expectedName := "mail-test"
+		expectedValue := "10 mx.terraform.io."
+		expectedType := "MX"
+		expectedTTL := "30"
+
+		return compareState(s[0], expectedName, expectedValue, expectedType, expectedTTL)
+	}
+
+	resourceName := "dyn_record.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDynRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckDynRecordConfig_MX_record, zone),
+			},
+			resource.TestStep{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateIdPrefix: fmt.Sprintf("MX/%s/terraform.%s/", zone, zone),
+				ImportStateCheck:    checkFn,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func compareState(recordState *terraform.InstanceState, expectedName, expectedValue, expectedType, expectedTTL string) error {
+	expectedZone := os.Getenv("DYN_ZONE")
+
+	if recordState.Attributes["zone"] != expectedZone {
+		return fmt.Errorf("expected zone of %s, %s received",
+			expectedZone, recordState.Attributes["zone"])
+	}
+	if recordState.Attributes["name"] != expectedName {
+		return fmt.Errorf("expected name of %s, %s received",
+			expectedName, recordState.Attributes["name"])
+	}
+	if recordState.Attributes["value"] != expectedValue {
+		return fmt.Errorf("expected value of %s, %s received",
+			expectedValue, recordState.Attributes["value"])
+	}
+	if recordState.Attributes["type"] != expectedType {
+		return fmt.Errorf("expected type of %s, %s received",
+			expectedType, recordState.Attributes["type"])
+	}
+	if recordState.Attributes["ttl"] != expectedTTL {
+		return fmt.Errorf("expected TTL of %s, %s received",
+			expectedTTL, recordState.Attributes["ttl"])
+	}
+
+	return nil
+}

--- a/dyn/resource_dyn_record.go
+++ b/dyn/resource_dyn_record.go
@@ -18,6 +18,9 @@ func resourceDynRecord() *schema.Resource {
 		Read:   resourceDynRecordRead,
 		Update: resourceDynRecordUpdate,
 		Delete: resourceDynRecordDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceDynRecordImportState,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"zone": &schema.Schema{

--- a/dyn/resource_dyn_record_test.go
+++ b/dyn/resource_dyn_record_test.go
@@ -176,7 +176,7 @@ func TestAccDynRecord_CNAME_topLevelDomain(t *testing.T) {
 				Config: fmt.Sprintf(testAccCheckDynRecordConfig_topLevelDomain, zone),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDynRecordExists("dyn_record.foobar", &record),
-					resource.TestCheckResourceAttr("dyn_record.foobar", "name", "hashicorptest.com"),
+					resource.TestCheckResourceAttr("dyn_record.foobar", "name", zone),
 					resource.TestCheckResourceAttr("dyn_record.foobar", "type", "A"),
 					resource.TestCheckResourceAttr("dyn_record.foobar", "ttl", "90"),
 					resource.TestCheckResourceAttr("dyn_record.foobar", "zone", zone),

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -39,3 +39,11 @@ The following attributes are exported:
 
 * `id` - The record ID.
 * `fqdn` - The FQDN of the record, built from the `name` and the `zone`.
+
+## Import
+
+Dyn records can be imported using a combination of the `type`, `zone`, `fdqn`, and optionally `id`.
+
+```
+$terraform import dyn_record.record {type}/{zone}/{fqdn}[/{id}]
+```


### PR DESCRIPTION
This allows dyn records to be imported with the following syntax:
```
terraform import dyn_record.foobar {type}/{zone}/{fqdn}[/{id}]
```

Additionally, this fixes `TestAccDynRecord_CNAME_topLevelDomain` which assumed that the `DYN_ZONE` provided was `hashicorptest.com`

Closes #7 
Closes #18 