### PR TITLE
add checks for record ID

### DIFF
--- a/dyn/resource_dyn_record.go
+++ b/dyn/resource_dyn_record.go
@@ -138,8 +138,15 @@ func resourceDynRecordRead(d *schema.ResourceData, meta interface{}) error {
 		Type: d.Get("type").(string),
 	}
 
-	err := client.GetRecord(record)
+	// Check if the ID actually exists
+	err := client.GetRecordID(record)
 	if err != nil {
+		d.SetId("")
+	}
+
+	err = client.GetRecord(record)
+	if err != nil {
+		d.SetId("") // If record is removed from the server this will help enforcing the terraform's local state
 		return fmt.Errorf("Couldn't find Dyn record: %s", err)
 	}
 


### PR DESCRIPTION
In case when someone removes a terraform managed record from remote manually, the provider is not able to detect the change. This is happening because the `GetRecord` method is returning `nil` in that case.
The reason for this could be https://github.com/nesv/go-dynect/blob/master/dynect/client.go#L176-L179 i.e. if content length is 0 then nil is returned.